### PR TITLE
Add initial dataset loading utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/data/CSL.py
+++ b/data/CSL.py
@@ -1,0 +1,70 @@
+# data/CSL.py
+import torch
+import pickle
+import os
+import dgl
+import numpy as np
+from dgl.data import DGLDataset
+from dgl.data.utils import download, _get_dgl_url, extract_archive
+from scipy.sparse import csc_matrix, save_npz, load_npz
+from tqdm import tqdm
+
+class CSLDataset(DGLDataset):
+    def __init__(self, data_dir, name, split_id=None):
+        self.name = name
+        self.split_id = split_id
+        self.data_dir = data_dir
+        self.g_list = []
+        self.y_list = []
+        self.n_samples = 150
+        self.num_node_type = 1
+        self.num_edge_type = 1
+
+        super(CSLDataset, self).__init__(name=name,
+                                         url=_get_dgl_url('graphforming/benchmarking-gnns/CSL.zip'),
+                                         raw_dir=data_dir,
+                                         force_reload=False)
+    
+    def download(self):
+        data_path = os.path.join(self.raw_dir, 'CSL.zip')
+        if not os.path.exists(data_path):
+            download(self.url, path=data_path)
+            extract_archive(data_path, os.path.join(self.raw_dir, self.name))
+
+    def process(self):
+        # Read the raw graph data
+        adj_path = os.path.join(self.raw_dir, self.name, 'graphs.npz')
+        y_path = os.path.join(self.raw_dir, self.name, 'y.npy')
+        adjs = load_npz(adj_path)
+        y = np.load(y_path)
+        
+        # Reconstruct graphs and labels
+        for i in range(self.n_samples):
+            g = dgl.from_scipy(csc_matrix(adjs[i]))
+            self.g_list.append(g)
+            self.y_list.append(y[i])
+
+        # Generate train/val/test splits
+        self.train = []
+        self.val = []
+        self.test = []
+        for i in range(5):
+            train_idx = np.loadtxt(os.path.join(self.raw_dir, self.name, 'train_split', f'{i}.txt'), dtype=int)
+            val_idx = np.loadtxt(os.path.join(self.raw_dir, self.name, 'val_split', f'{i}.txt'), dtype=int)
+            test_idx = np.loadtxt(os.path.join(self.raw_dir, self.name, 'test_split', f'{i}.txt'), dtype=int)
+            
+            self.train.append([(self.g_list[j], self.y_list[j]) for j in train_idx])
+            self.val.append([(self.g_list[j], self.y_list[j]) for j in val_idx])
+            self.test.append([(self.g_list[j], self.y_list[j]) for j in test_idx])
+
+    def __getitem__(self, i):
+        return self.g_list[i], self.y_list[i]
+
+    def __len__(self):
+        return self.n_samples
+
+    def collate(self, samples):
+        graphs, labels = map(list, zip(*samples))
+        batched_graph = dgl.batch(graphs)
+        labels = torch.tensor(labels).long()
+        return batched_graph, labels

--- a/data/SBMs.py
+++ b/data/SBMs.py
@@ -1,0 +1,45 @@
+# data/SBMs.py
+import torch
+import pickle
+import os
+import dgl
+from dgl.data import DGLDataset
+from dgl.data.utils import download, _get_dgl_url, extract_archive
+from tqdm import tqdm
+
+class SBMsDataset(DGLDataset):
+    def __init__(self, data_dir, name):
+        self.name = name
+        self.data_dir = data_dir
+        self.url = _get_dgl_url(f'graphforming/benchmarking-gnns/{self.name}.zip')
+        
+        super(SBMsDataset, self).__init__(name=name)
+
+    def download(self):
+        data_path = os.path.join(self.data_dir, f'{self.name}.zip')
+        if not os.path.exists(data_path):
+            download(self.url, path=data_path)
+            extract_archive(data_path, os.path.join(self.data_dir, self.name))
+
+    def process(self):
+        data_path = os.path.join(self.data_dir, self.name)
+        with open(os.path.join(data_path, f'{self.name}_train.pkl'), 'rb') as f:
+            self.train = pickle.load(f)
+        with open(os.path.join(data_path, f'{self.name}_val.pkl'), 'rb') as f:
+            self.val = pickle.load(f)
+        with open(os.path.join(data_path, f'{self.name}_test.pkl'), 'rb') as f:
+            self.test = pickle.load(f)
+
+    def __getitem__(self, idx):
+        # This is a placeholder
+        return self.train[idx]
+
+    def __len__(self):
+        return len(self.train)
+
+    def collate(self, samples):
+        # The input samples is a list of pairs (graph, label).
+        graphs, labels = map(list, zip(*samples))
+        batched_graph = dgl.batch(graphs)
+        labels = torch.cat(labels).long()
+        return batched_graph, labels

--- a/data/data.py
+++ b/data/data.py
@@ -1,0 +1,86 @@
+# data/data.py
+import os
+import pickle
+import torch
+from scipy.spatial.distance import cdist
+
+from data.molecules import MoleculeDataset
+from data.SBMs import SBMsDataset
+from data.CYCLES import CYCLES_Dataset
+from data.graphtheoryprop import GraphTheoryPropDataset
+from data.CSL import CSLDataset
+from data.superpixels import SuperPixDataset
+from data.TUs import TUsDataset
+from data.TSP import TSPDataset
+from data.COLLAB import COLLABDataset
+from data.WikiCS import WikiCSDataset
+
+from dgl.data import download as dgl_download
+from dgl.data.utils import inférieure_url, extract_archive
+
+class LoadData:
+    def __init__(self, data_dir, dataset_name):
+        self.data_dir = data_dir
+        self.dataset_name = dataset_name
+        self.dataset = self.load_dataset()
+
+    def load_dataset(self):
+        """
+        Loading datasets
+        """
+        if self.dataset_name == 'AQSOL':
+            return MoleculeDataset(self.data_dir, self.dataset_name)
+        elif self.dataset_name == 'ZINC':
+            return MoleculeDataset(self.data_dir, self.dataset_name)
+        elif self.dataset_name == 'SBM_CLUSTER':
+            return SBMsDataset(self.data_dir, 'SBM_CLUSTER')
+        elif self.dataset_name == 'SBM_PATTERN':
+            return SBMsDataset(self.data_dir, 'SBM_PATTERN')
+        elif self.dataset_name == 'CYCLES':
+            return CYCLES_Dataset(self.data_dir, 'CYCLES')
+        elif self.dataset_name == 'GraphTheoryProp':
+            return GraphTheoryPropDataset(self.data_dir, 'GraphTheoryProp')
+        elif self.dataset_name == 'CSL':
+            return CSLDataset(self.data_dir, 'CSL')
+        elif self.dataset_name == "MNIST" or self.dataset_name == "CIFAR10":
+            return SuperPixDataset(self.data_dir, self.dataset_name)
+        elif self.dataset_name in ['DD', 'ENZYMES', 'PROTEINS_full']:
+            return TUsDataset(self.data_dir, self.dataset_name)
+        elif self.dataset_name == 'TSP':
+            return TSPDataset(self.data_dir, self.dataset_name)
+        elif self.dataset_name == 'COLLAB':
+            return COLLABDataset(self.data_dir, self.dataset_name)
+        elif self.dataset_name == 'WikiCS':
+            return WikiCSDataset(self.data_dir, self.dataset_name)
+        else:
+            raise ValueError(f"Unknown dataset: {self.dataset_name}")
+
+    def _add_positional_encodings(self, pos_enc_dim):
+        """
+        Loading positional encodings
+        """
+        # We use Laplacian PE for PNA and GSN.
+        self.dataset.train.graph_lists = [self._laplacian_positional_encoding(g, pos_enc_dim) for g in self.dataset.train.graph_lists]
+        self.dataset.val.graph_lists = [self._laplacian_positional_encoding(g, pos_enc_dim) for g in self.dataset.val.graph_lists]
+        self.dataset.test.graph_lists = [self._laplacian_positional_encoding(g, pos_enc_dim) for g in self.dataset.test.graph_lists]
+
+    def _laplacian_positional_encoding(self, g, pos_enc_dim):
+        """
+        Graph positional encoding v/ Laplacian eigenvectors
+        """
+        # Laplacian
+        A = g.adjacency_matrix_scipy(return_edge_ids=False).astype(float)
+        N = g.number_of_nodes()
+        D = torch.diag(torch.sum(torch.from_numpy(A.toarray()), 1))
+        L = D - torch.from_numpy(A.toarray())
+        
+        # Eigenvectors
+        eigval, eigvec = torch.linalg.eigh(L)
+        
+        # Keep smallest non-zero eig
+        idx = (eigval > 1e-6).nonzero().squeeze()
+        
+        g.ndata['pos_enc'] = eigvec[:, idx[:pos_enc_dim]].float()
+        
+        return g
+

--- a/data/molecules.py
+++ b/data/molecules.py
@@ -1,0 +1,47 @@
+# data/molecules.py
+import torch
+import pickle
+import os
+import dgl
+from dgl.data import DGLDataset
+from dgl.data.utils import download, _get_dgl_url
+from tqdm import tqdm
+
+class MoleculeDataset(DGLDataset):
+    def __init__(self, data_dir, name):
+        self.name = name
+        self.data_dir = data_dir
+        self.url = _get_dgl_url(f'graphforming/benchmarking-gnns/{self.name}.zip')
+        
+        super(MoleculeDataset, self).__init__(name=name)
+
+    def download(self):
+        data_path = os.path.join(self.data_dir, f'{self.name}.zip')
+        if not os.path.exists(data_path):
+            download(self.url, path=data_path)
+            extract_archive(data_path, os.path.join(self.data_dir, self.name))
+
+    def process(self):
+        self.train = torch.load(os.path.join(self.data_dir, self.name, f'{self.name}_train.pt'))
+        self.val = torch.load(os.path.join(self.data_dir, self.name, f'{self.name}_val.pt'))
+        self.test = torch.load(os.path.join(self.data_dir, self.name, f'{self.name}_test.pt'))
+        
+        # Process node and edge features
+        self.num_atom_type = 0
+        self.num_bond_type = 0
+        if self.train.graph_lists:
+            self.num_atom_type = self.train.graph_lists[0].ndata['feat'].shape[1]
+            self.num_bond_type = self.train.graph_lists[0].edata['feat'].shape[1]
+
+    def __getitem__(self, idx):
+        # This is just a placeholder, the actual data is in self.train, self.val, self.test
+        return self.train[idx]
+
+    def __len__(self):
+        return len(self.train.graph_lists)
+        
+    def collate(self, samples):
+        graphs, labels = map(list, zip(*samples))
+        batched_graph = dgl.batch(graphs)
+        return batched_graph, torch.tensor(labels)
+

--- a/data/script_download_all_datasets.sh
+++ b/data/script_download_all_datasets.sh
@@ -1,0 +1,49 @@
+# data/script_download_all_datasets.sh
+
+#!/bin/bash
+
+# Define the base URL for downloads
+BASE_URL="https://data.dgl.ai/dataset/graphforming/benchmarking-gnns"
+
+# List of datasets to download
+DATASETS=(
+  "AQSOL.zip"
+  "ZINC.zip"
+  "SBM_CLUSTER.zip"
+  "SBM_PATTERN.zip"
+  "CYCLES.zip"
+  "GraphTheoryProp.zip"
+  "CSL.zip"
+  "MNIST.zip"
+  "CIFAR10.zip"
+  "TUs.zip"
+  "TSP.zip"
+  "COLLAB.zip"
+  "WikiCS.zip"
+)
+
+# Create data directory if it doesn't exist
+mkdir -p data
+cd data
+
+echo "Starting download of all datasets..."
+
+# Loop through and download each dataset
+for ds in "${DATASETS[@]}"; do
+  echo "Downloading ${ds}..."
+  if [ ! -f "$ds" ]; then
+    wget "${BASE_URL}/${ds}"
+    if [ $? -eq 0 ]; then
+      echo "${ds} downloaded successfully."
+      # Unzip the file, removing the .zip extension for the folder name
+      unzip -q "$ds" -d "${ds%.zip}" && rm "$ds"
+      echo "Extracted ${ds}."
+    else
+      echo "Failed to download ${ds}."
+    fi
+  else
+    echo "${ds} already exists. Skipping download."
+  fi
+done
+
+echo "All datasets downloaded and extracted."


### PR DESCRIPTION
## Summary
- add general dataset loading logic in `data/data.py`
- implement dataset handlers for molecules, SBMs, and CSL datasets
- provide a script to download all benchmark datasets
- ignore Python cache files

## Testing
- `python -m py_compile data/data.py data/molecules.py data/SBMs.py data/CSL.py`

------
https://chatgpt.com/codex/tasks/task_e_684857e53e84832bb04f1c2cf5fc6ef8